### PR TITLE
增加 removeByDomainWithKeys 支援部份名稱或 * 前導名稱，並可指定多個參數必須同時存在才清除這些參數；版本增加到 1.13

### DIFF
--- a/src/TrackingTokenStripper.user.js
+++ b/src/TrackingTokenStripper.user.js
@@ -119,7 +119,9 @@
             .removeByDomain('www.bilibili.com', 'share_medium')
 
             // Substack related email
-            .removeByDomainWithKeys(null, 'publication_id', 'post_id', 'isFreemail', 'r', 'token', 'triedRedirect')
+            .removeByDomainThatMatchAllKeys("*.substack.com", ['publication_id', 'post_id', 'isFreemail', 'r', 'token', 'triedRedirect'])
+            .removeByDomainThatMatchAllKeys("unchartedterritories.tomaspueyo.com", ['publication_id', 'post_id', 'isFreemail', 'r', 'token', 'triedRedirect'])
+            .removeByDomainThatMatchAllKeys("www.latent.space", ['publication_id', 'post_id', 'isFreemail', 'r', 'token', 'triedRedirect'])
 
             // Others
             .remove('__tn__')
@@ -190,7 +192,7 @@
                  * @param  {...string} keys 不定個數的 query string keys
                  * @returns {object} 返回 TrackingTokenStripper 物件
                  */
-                removeByDomainWithKeys(domain, ...keys) {
+                removeByDomainThatMatchAllKeys(domain, keys) {
                     const hostname = parsedUrl.hostname.toLocaleLowerCase();
                     const normalizedDomain = domain ? domain.toLocaleLowerCase() : null;
 

--- a/src/TrackingTokenStripper.user.js
+++ b/src/TrackingTokenStripper.user.js
@@ -119,7 +119,7 @@
             .removeByDomain('www.bilibili.com', 'share_medium')
 
             // Substack related email
-            .removeByDomain(null, 'publication_id', 'post_id', 'isFreemail', 'r', 'token', 'triedRedirect')
+            .removeByDomainWithKeys(null, 'publication_id', 'post_id', 'isFreemail', 'r', 'token', 'triedRedirect')
 
             // Others
             .remove('__tn__')
@@ -172,13 +172,25 @@
                     }
                     return TrackingTokenStripper(parsedUrl.toString());
                 },
+                removeByDomain(domain, name) {
+                    if (parsedUrl.hostname.toLocaleLowerCase() === domain.toLocaleLowerCase()) {
+                        if (name.indexOf('=') >= 0) {
+                            var [key, value] = name.split("=");
+                            return this.remove(key, value);
+                        } else {
+                            return this.remove(name);
+                        }
+                    } else {
+                        return this;
+                    }
+                },
                 /**
                  * 僅當所有 keys 都存在時，移除這些 Query string keys
                  * @param {string|null} domain 指定的 domain，若為 null 則符合所有域名
                  * @param  {...string} keys 不定個數的 query string keys
                  * @returns {object} 返回 TrackingTokenStripper 物件
                  */
-                removeByDomain(domain, ...keys) {
+                removeByDomainWithKeys(domain, ...keys) {
                     const hostname = parsedUrl.hostname.toLocaleLowerCase();
                     const normalizedDomain = domain ? domain.toLocaleLowerCase() : null;
 

--- a/src/TrackingTokenStripper.user.js
+++ b/src/TrackingTokenStripper.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         網站追蹤碼移除工具
-// @version      1.12
+// @version      1.13
 // @description  移除大多數網站附加在超連結上的 Query String 追蹤碼
 // @license      MIT
 // @homepage     https://blog.miniasp.com/
@@ -118,6 +118,19 @@
             .removeByDomain('www.bilibili.com', 'share_source')
             .removeByDomain('www.bilibili.com', 'share_medium')
 
+            // Substack, Latent Space
+            .removeByDomain('*.substack.com', 'publication_id')
+            .removeByDomain('*.substack.com', 'post_id')
+            .removeByDomain('*.substack.com', 'isFreemail')
+            .removeByDomain('*.substack.com', 'r')
+            .removeByDomain('*.substack.com', 'triedRedirect')
+
+            .removeByDomain('www.latent.space', 'publication_id')
+            .removeByDomain('www.latent.space', 'post_id')
+            .removeByDomain('www.latent.space', 'isFreemail')
+            .removeByDomain('www.latent.space', 'r')
+            .removeByDomain('www.latent.space', 'triedRedirect')
+
             // Others
             .remove('__tn__')
             .remove('gclsrc')
@@ -170,16 +183,28 @@
                     return TrackingTokenStripper(parsedUrl.toString());
                 },
                 removeByDomain(domain, name) {
-                    if (parsedUrl.hostname.toLocaleLowerCase() === domain.toLocaleLowerCase()) {
+                    const hostname = parsedUrl.hostname.toLocaleLowerCase();
+                    const normalizedDomain = domain.toLocaleLowerCase();
+        
+                    // 支援通配符匹配，例如 `*.substack.com` 或 `.substack.com`
+                    const isWildcard = normalizedDomain.startsWith('*') || normalizedDomain.startsWith('.');
+                    const domainToMatch = isWildcard
+                        ? normalizedDomain.replace(/^\*\./, '').replace(/^\./, '') // 移除通配符
+                        : normalizedDomain;
+        
+                    const domainMatch = isWildcard
+                        ? hostname.endsWith(domainToMatch) // 通配符只檢查是否以指定域名結尾
+                        : hostname === domainToMatch; // 非通配符完全匹配
+        
+                    if (domainMatch) {
                         if (name.indexOf('=') >= 0) {
                             var [key, value] = name.split("=");
                             return this.remove(key, value);
                         } else {
                             return this.remove(name);
                         }
-                    } else {
-                        return this;
                     }
+                    return this;
                 },
                 toString() {
                     return parsedUrl.toString();


### PR DESCRIPTION
removeByDomain 增加支援部份名稱或 * 前導名稱 功能是由 ChatGPT 4o 更新。
很少有機會發 PR，希望沒有破壞或冒犯到什麼。